### PR TITLE
Fix the order for css according to the HTML5Boilerplate

### DIFF
--- a/frontend/views/layouts/main.php
+++ b/frontend/views/layouts/main.php
@@ -26,8 +26,8 @@
 	<meta name="keywords" content="">
 	<meta name="viewport" content="width=device-width,initial-scale=1">
 
-	<link rel="stylesheet" href="<?php echo Yii::app()->request->baseUrl; ?>/css/main.css">
 	<link rel="stylesheet" href="<?php echo Yii::app()->request->baseUrl; ?>/css/normalize.css">
+	<link rel="stylesheet" href="<?php echo Yii::app()->request->baseUrl; ?>/css/main.css">
 	<link rel="stylesheet" type="text/css" href="<?php echo Yii::app()->request->baseUrl; ?>/css/styles.css"/>
 	<!--using less instead? file not included-->
 	<!--<link rel="stylesheet/less" type="text/css" href="/less/styles.less">-->


### PR DESCRIPTION
Seems that the declarations of HTML5Boilerplate's css files are swapped for some reason. Is that a mistake or is there some reason i'm not familiar with?
