### PR TITLE
Update frontend/views/layouts/main.php

### DIFF
--- a/frontend/views/layouts/main.php
+++ b/frontend/views/layouts/main.php
@@ -17,7 +17,8 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-
+	<link rel="stylesheet" href="<?php echo Yii::app()->request->baseUrl; ?>/css/normalize.css">
+	
 	<!-- Use the .htaccess and remove these lines to avoid edge case issues. More info: h5bp.com/b/378 -->
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
@@ -26,7 +27,7 @@
 	<meta name="keywords" content="">
 	<meta name="viewport" content="width=device-width,initial-scale=1">
 
-	<link rel="stylesheet" href="<?php echo Yii::app()->request->baseUrl; ?>/css/normalize.css">
+
 	<link rel="stylesheet" href="<?php echo Yii::app()->request->baseUrl; ?>/css/main.css">
 	<link rel="stylesheet" type="text/css" href="<?php echo Yii::app()->request->baseUrl; ?>/css/styles.css"/>
 	<!--using less instead? file not included-->


### PR DESCRIPTION
Put normalize.css to the top to avoid Bootstrap conflicts. 

Example: When I use the YiiBooster Page Header example, the h1 has the same font-size than small tag.

<div class="page-header">
      <h1>Example page header <small>Subtext for header</small></h1>
</div>
