### PR TITLE
Fix i18n basePath issuse

### DIFF
--- a/common/config/overrides/base.php
+++ b/common/config/overrides/base.php
@@ -34,7 +34,7 @@ return [
                     'cacheTableName' => 'cache',
                 ],
         'messages' => [
-            'basePath' => 'common.messages'
+            'basePath' => 'common/messages'
         ],
         'log' => [
             'class' => 'CLogRouter',


### PR DESCRIPTION
According to CPhpMessageSource specs  (http://www.yiiframework.com/doc/api/1.1/CPhpMessageSource#basePath-detail), basePath should be separeted with "/".
